### PR TITLE
fix: harden widget detection against cheating

### DIFF
--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { execSync } from 'node:child_process'
 import { resolve } from 'node:path'
+import { detectWidget } from '../src/cron/healthcheck'
 
 /**
  * Input schema for new member submissions.
@@ -142,9 +143,8 @@ for (const member of newMembers) {
       write(`- PASS: ${safeUrl} responded with HTTP ${res.status}`)
 
       const body = await res.text()
-      const lower = body.toLowerCase()
-      if (lower.includes('data-webring="ca"') || lower.includes('webring.ca/embed.js')) {
-        write('- PASS: Webring widget detected')
+      if (detectWidget(body)) {
+        write('- PASS: Webring widget detected (marker + prev/next links)')
       } else {
         write('- INFO: Widget not detected yet. Install the widget before or after merge — see https://github.com/stanleypangg/webring.ca#add-the-widget')
       }

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { execSync } from 'node:child_process'
 import { resolve } from 'node:path'
-import { detectWidget } from '../src/cron/healthcheck'
+import { detectWidget } from '../src/utils/widget'
 
 /**
  * Input schema for new member submissions.

--- a/src/__tests__/healthcheck.test.ts
+++ b/src/__tests__/healthcheck.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { runHealthCheck } from '../cron/healthcheck'
+import { runHealthCheck, detectWidget } from '../cron/healthcheck'
 import { createMockKV } from './kv-mock'
 import type { Member, HealthStatus } from '../types'
+
+const VALID_WIDGET = '<div data-webring="ca" data-member="alice"></div><a href="https://webring.ca/prev/alice">prev</a><a href="https://webring.ca/next/alice">next</a><script src="https://webring.ca/embed.js"></script>'
 
 const alice: Member = { slug: 'alice', name: 'Alice', url: 'https://alice.example.com', type: 'developer', active: true }
 const bob: Member = { slug: 'bob', name: 'Bob', url: 'https://bob.example.com', type: 'designer', active: true }
@@ -30,11 +32,51 @@ function mockFetch(responses: Record<string, { ok: boolean; status: number; body
   }) as typeof fetch
 }
 
+describe('detectWidget', () => {
+  it('detects valid widget with marker and links', () => {
+    expect(detectWidget(VALID_WIDGET)).toBe(true)
+  })
+
+  it('detects widget with embed script and links', () => {
+    const html = '<script src="https://webring.ca/embed.js"></script><a href="https://webring.ca/prev/alice">prev</a><a href="https://webring.ca/next/alice">next</a>'
+    expect(detectWidget(html)).toBe(true)
+  })
+
+  it('rejects marker hidden in HTML comment', () => {
+    const html = '<!-- <div data-webring="ca"></div> --><a href="https://webring.ca/prev/alice">prev</a><a href="https://webring.ca/next/alice">next</a>'
+    expect(detectWidget(html)).toBe(false)
+  })
+
+  it('rejects marker without prev/next links', () => {
+    const html = '<div data-webring="ca"></div><script src="https://webring.ca/embed.js"></script>'
+    expect(detectWidget(html)).toBe(false)
+  })
+
+  it('rejects prev/next links without marker', () => {
+    const html = '<a href="https://webring.ca/prev/alice">prev</a><a href="https://webring.ca/next/alice">next</a>'
+    expect(detectWidget(html)).toBe(false)
+  })
+
+  it('rejects when only prev link is present', () => {
+    const html = '<div data-webring="ca"></div><a href="https://webring.ca/prev/alice">prev</a>'
+    expect(detectWidget(html)).toBe(false)
+  })
+
+  it('rejects when only next link is present', () => {
+    const html = '<div data-webring="ca"></div><a href="https://webring.ca/next/alice">next</a>'
+    expect(detectWidget(html)).toBe(false)
+  })
+
+  it('rejects empty page', () => {
+    expect(detectWidget('<html></html>')).toBe(false)
+  })
+})
+
 describe('runHealthCheck', () => {
   it('marks members as ok when site is reachable with widget', async () => {
     const kv = createMockKV({ members: JSON.stringify([alice]) })
     mockFetch({
-      'https://alice.example.com': { ok: true, status: 200, body: '<div data-webring="ca" data-member="alice"></div><script src="https://webring.ca/embed.js"></script>' },
+      'https://alice.example.com': { ok: true, status: 200, body: VALID_WIDGET },
     })
 
     await runHealthCheck(kv)
@@ -58,6 +100,45 @@ describe('runHealthCheck', () => {
     const status: HealthStatus = JSON.parse(raw!)
     expect(status.status).toBe('widget_missing')
     expect(status.consecutiveFails).toBe(1)
+  })
+
+  it('marks as widget_missing when marker is in a comment', async () => {
+    const kv = createMockKV({ members: JSON.stringify([alice]) })
+    mockFetch({
+      'https://alice.example.com': { ok: true, status: 200, body: '<!-- <div data-webring="ca"></div> --><a href="https://webring.ca/prev/alice">prev</a><a href="https://webring.ca/next/alice">next</a>' },
+    })
+
+    await runHealthCheck(kv)
+
+    const raw = await kv.get('health:alice')
+    const status: HealthStatus = JSON.parse(raw!)
+    expect(status.status).toBe('widget_missing')
+  })
+
+  it('marks as widget_missing when marker present but no links', async () => {
+    const kv = createMockKV({ members: JSON.stringify([alice]) })
+    mockFetch({
+      'https://alice.example.com': { ok: true, status: 200, body: '<div data-webring="ca"></div>' },
+    })
+
+    await runHealthCheck(kv)
+
+    const raw = await kv.get('health:alice')
+    const status: HealthStatus = JSON.parse(raw!)
+    expect(status.status).toBe('widget_missing')
+  })
+
+  it('sends a browser User-Agent', async () => {
+    const kv = createMockKV({ members: JSON.stringify([alice]) })
+    mockFetch({
+      'https://alice.example.com': { ok: true, status: 200, body: VALID_WIDGET },
+    })
+
+    await runHealthCheck(kv)
+
+    const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    const headers = call[1]?.headers as Record<string, string>
+    expect(headers['User-Agent']).toMatch(/^Mozilla\/5\.0/)
   })
 
   it('marks members as unreachable on network error', async () => {
@@ -114,7 +195,7 @@ describe('runHealthCheck', () => {
     const inactiveAlice = { ...alice, active: false }
     const kv = createMockKV({ members: JSON.stringify([inactiveAlice]) })
     mockFetch({
-      'https://alice.example.com': { ok: true, status: 200, body: '<script src="https://webring.ca/embed.js"></script>' },
+      'https://alice.example.com': { ok: true, status: 200, body: VALID_WIDGET },
     })
 
     await runHealthCheck(kv)
@@ -127,7 +208,7 @@ describe('runHealthCheck', () => {
   it('does not update members if no status changes', async () => {
     const kv = createMockKV({ members: JSON.stringify([alice]) })
     mockFetch({
-      'https://alice.example.com': { ok: true, status: 200, body: '<div data-webring="ca"></div>' },
+      'https://alice.example.com': { ok: true, status: 200, body: VALID_WIDGET },
     })
     const putSpy = vi.spyOn(kv, 'put')
 
@@ -139,9 +220,10 @@ describe('runHealthCheck', () => {
 
   it('handles multiple members in parallel', async () => {
     const kv = createMockKV({ members: JSON.stringify([alice, bob]) })
+    const bobWidget = '<div data-webring="ca"></div><a href="https://webring.ca/prev/bob">prev</a><a href="https://webring.ca/next/bob">next</a>'
     mockFetch({
-      'https://alice.example.com': { ok: true, status: 200, body: '<div data-webring="ca"></div>' },
-      'https://bob.example.com': { ok: true, status: 200, body: '<script src="https://webring.ca/embed.js"></script>' },
+      'https://alice.example.com': { ok: true, status: 200, body: VALID_WIDGET },
+      'https://bob.example.com': { ok: true, status: 200, body: bobWidget },
     })
 
     await runHealthCheck(kv)

--- a/src/__tests__/healthcheck.test.ts
+++ b/src/__tests__/healthcheck.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { runHealthCheck, detectWidget } from '../cron/healthcheck'
+import { runHealthCheck } from '../cron/healthcheck'
+import { detectWidget } from '../utils/widget'
 import { createMockKV } from './kv-mock'
 import type { Member, HealthStatus } from '../types'
 

--- a/src/cron/healthcheck.ts
+++ b/src/cron/healthcheck.ts
@@ -1,8 +1,25 @@
 import type { HealthStatus } from '../types'
 import { getMembers, setMembers, getHealthStatus, setHealthStatus } from '../data'
 
+const USER_AGENTS = [
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0',
+]
+
+export function detectWidget(html: string): boolean {
+  const stripped = html.toLowerCase().replace(/<!--[\s\S]*?-->/g, '')
+  const hasMarker = stripped.includes('data-webring="ca"') || stripped.includes('webring.ca/embed.js')
+  const hasPrev = /href=["'][^"']*webring\.ca\/prev\//.test(stripped)
+  const hasNext = /href=["'][^"']*webring\.ca\/next\//.test(stripped)
+  return hasMarker && hasPrev && hasNext
+}
+
 export async function runHealthCheck(kv: KVNamespace): Promise<void> {
   const members = await getMembers(kv)
+  const ua = USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)]
 
   const prevStatuses = await Promise.all(
     members.map((m) => getHealthStatus(kv, m.slug))
@@ -14,11 +31,10 @@ export async function runHealthCheck(kv: KVNamespace): Promise<void> {
       try {
         const res = await fetch(member.url, {
           signal: AbortSignal.timeout(5000),
-          headers: { 'User-Agent': 'webring.ca health check' },
+          headers: { 'User-Agent': ua },
         })
         const body = await res.text()
-        const lower = body.toLowerCase()
-        const hasWidget = lower.includes('data-webring="ca"') || lower.includes('webring.ca/embed.js')
+        const hasWidget = detectWidget(body)
 
         if (res.ok && hasWidget) {
           return {

--- a/src/cron/healthcheck.ts
+++ b/src/cron/healthcheck.ts
@@ -1,5 +1,6 @@
 import type { HealthStatus } from '../types'
 import { getMembers, setMembers, getHealthStatus, setHealthStatus } from '../data'
+import { detectWidget } from '../utils/widget'
 
 const USER_AGENTS = [
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
@@ -9,17 +10,12 @@ const USER_AGENTS = [
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0',
 ]
 
-export function detectWidget(html: string): boolean {
-  const stripped = html.toLowerCase().replace(/<!--[\s\S]*?-->/g, '')
-  const hasMarker = stripped.includes('data-webring="ca"') || stripped.includes('webring.ca/embed.js')
-  const hasPrev = /href=["'][^"']*webring\.ca\/prev\//.test(stripped)
-  const hasNext = /href=["'][^"']*webring\.ca\/next\//.test(stripped)
-  return hasMarker && hasPrev && hasNext
+function randomUA(): string {
+  return USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)]
 }
 
 export async function runHealthCheck(kv: KVNamespace): Promise<void> {
   const members = await getMembers(kv)
-  const ua = USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)]
 
   const prevStatuses = await Promise.all(
     members.map((m) => getHealthStatus(kv, m.slug))
@@ -31,7 +27,7 @@ export async function runHealthCheck(kv: KVNamespace): Promise<void> {
       try {
         const res = await fetch(member.url, {
           signal: AbortSignal.timeout(5000),
-          headers: { 'User-Agent': ua },
+          headers: { 'User-Agent': randomUA() },
         })
         const body = await res.text()
         const hasWidget = detectWidget(body)

--- a/src/utils/widget.ts
+++ b/src/utils/widget.ts
@@ -1,0 +1,21 @@
+/**
+ * Detect whether an HTML page contains a valid webring widget.
+ *
+ * Requires all of:
+ * 1. A marker: `data-webring="ca"` attribute or `webring.ca/embed.js` script
+ * 2. A prev link: `href` pointing to `webring.ca/prev/`
+ * 3. A next link: `href` pointing to `webring.ca/next/`
+ *
+ * HTML comments are stripped before detection so hidden markers don't pass.
+ *
+ * Known limitation: the prev/next links are not checked against a specific
+ * member slug. A site could embed another member's widget HTML and pass.
+ * In practice, using the embed script generates correct links automatically.
+ */
+export function detectWidget(html: string): boolean {
+  const stripped = html.toLowerCase().replace(/<!--[\s\S]*?-->/g, '')
+  const hasMarker = stripped.includes('data-webring="ca"') || stripped.includes('webring.ca/embed.js')
+  const hasPrev = /href=["'][^"']*webring\.ca\/prev\//.test(stripped)
+  const hasNext = /href=["'][^"']*webring\.ca\/next\//.test(stripped)
+  return hasMarker && hasPrev && hasNext
+}


### PR DESCRIPTION
## Summary

- Randomize User-Agent with common browser strings so sites can't serve different content to the health check bot
- Strip HTML comments before detection so `<!-- data-webring="ca" -->` doesn't pass
- Require both prev and next webring navigation links alongside the marker attribute or script tag
- Extract shared `detectWidget()` function used by both health check cron and PR validation script

## Test plan

- [x] 54 tests pass (11 new)
- [x] TypeScript compiles cleanly
- [ ] Verify `detectWidget` rejects: comment-only markers, marker without links, links without marker, missing prev or next
- [ ] Verify health check sends a `Mozilla/5.0` User-Agent