### PR TITLE
feat: add embed.js widget

### DIFF
--- a/public/embed.js
+++ b/public/embed.js
@@ -1,0 +1,70 @@
+(function () {
+  var el = document.querySelector('div[data-webring="ca"]')
+  if (!el) return
+  if (el.shadowRoot) return
+
+  var slug = el.getAttribute('data-member')
+  var valid = slug && /^[a-z0-9-]+$/.test(slug)
+
+  var BASE = 'https://webring.ca'
+
+  var LEAF_SVG =
+    '<svg viewBox="2840 300 3920 4230" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style="width:1.1em;height:1.1em;vertical-align:-0.15em;fill:currentColor">' +
+    '<path d="M4890 4430L4845 3567A95 95 0 0 1 4956 3469L5815 3620 5699 3300A65 65 0 0 1 5719 3227L6660 2465 6448 2366A65 65 0 0 1 6414 2287L6600 1715 6058 1830A65 65 0 0 1 5985 1792L5880 1545 5457 1999A65 65 0 0 1 5346 1942L5550 890 5223 1079A65 65 0 0 1 5132 1052L4800 400 4468 1052A65 65 0 0 1 4377 1079L4050 890 4254 1942A65 65 0 0 1 4143 1999L3720 1545 3615 1792A65 65 0 0 1 3542 1830L3000 1715 3186 2287A65 65 0 0 1 3152 2366L2940 2465 3881 3227A65 65 0 0 1 3901 3300L3785 3620 4644 3469A95 95 0 0 1 4755 3567L4710 4430Z"/>' +
+    '</svg>'
+
+  var STYLES =
+    ':host{display:block;font-family:var(--webring-font,system-ui,-apple-system,BlinkMacSystemFont,sans-serif);font-size:var(--webring-size,0.8rem);color:var(--webring-color,inherit)}' +
+    'nav{display:flex;align-items:center;justify-content:center;gap:0.75em;padding:0.5em 1em;background:var(--webring-bg,rgba(128,128,128,0.06));border:1px solid var(--webring-border,rgba(128,128,128,0.2));border-radius:var(--webring-radius,6px)}' +
+    'a{color:var(--webring-color,inherit);text-decoration:none;transition:color 0.2s ease;white-space:nowrap}' +
+    'a:hover{color:var(--webring-accent,#AF272F)}' +
+    '.center{display:inline-flex;align-items:center;gap:0.3em}'
+
+  function render(root) {
+    var style = document.createElement('style')
+    style.textContent = STYLES
+    root.appendChild(style)
+
+    var nav = document.createElement('nav')
+    nav.setAttribute('aria-label', 'webring.ca navigation')
+
+    if (valid) {
+      var prev = document.createElement('a')
+      prev.href = BASE + '/prev/' + slug
+      prev.target = '_top'
+      prev.rel = 'noopener'
+      prev.textContent = '\u2190 Prev'
+      nav.appendChild(prev)
+    }
+
+    var center = document.createElement('a')
+    center.href = BASE
+    center.target = '_top'
+    center.rel = 'noopener'
+    center.className = 'center'
+    center.innerHTML = LEAF_SVG + ' webring.ca'
+    nav.appendChild(center)
+
+    if (valid) {
+      var next = document.createElement('a')
+      next.href = BASE + '/next/' + slug
+      next.target = '_top'
+      next.rel = 'noopener'
+      next.textContent = 'Next \u2192'
+      nav.appendChild(next)
+    }
+
+    root.appendChild(nav)
+  }
+
+  if (!valid) {
+    console.warn('webring.ca embed: missing or invalid data-member attribute')
+  }
+
+  if (el.attachShadow) {
+    var shadow = el.attachShadow({ mode: 'open' })
+    render(shadow)
+  } else {
+    render(el)
+  }
+})()

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { resolve } from 'node:path'
 import { detectWidget } from '../src/utils/widget'
 import { hasResolvableMemberCoordinates } from '../src/utils/member-coords'
@@ -40,7 +40,7 @@ let baseMembers: MemberInput[] = []
 try {
   const ref = process.env.PR_BASE_SHA
     || (process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : 'main')
-  const base = execSync(`git show ${ref}:members.json`, {
+  const base = execFileSync('git', ['show', `${ref}:members.json`], {
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
   })
@@ -151,7 +151,7 @@ for (const { current, base, changedFields } of editedMembers) {
 
           const body = await res.text()
           if (detectWidget(body, current.slug)) {
-            write('- PASS: Webring widget detected (marker + prev/next links)')
+            write('- PASS: Webring widget detected')
           } else {
             write('- INFO: Widget not detected on new URL. Make sure to install the widget — see https://github.com/stanleypangg/webring.ca#add-the-widget')
           }
@@ -247,7 +247,7 @@ for (const member of newMembers) {
 
       const body = await res.text()
       if (detectWidget(body, member.slug)) {
-        write('- PASS: Webring widget detected (marker + prev/next links)')
+        write('- PASS: Webring widget detected')
       } else {
         write('- INFO: Widget not detected yet. Install the widget before or after merge — see https://github.com/stanleypangg/webring.ca#add-the-widget')
       }

--- a/src/__tests__/healthcheck.test.ts
+++ b/src/__tests__/healthcheck.test.ts
@@ -48,9 +48,40 @@ describe('detectWidget', () => {
     expect(detectWidget(html)).toBe(false)
   })
 
-  it('rejects marker without prev/next links', () => {
-    const html = '<div data-webring="ca"></div><script src="https://webring.ca/embed.js"></script>'
+  it('rejects marker alone without embed script or prev/next links', () => {
+    const html = '<div data-webring="ca"></div>'
     expect(detectWidget(html)).toBe(false)
+  })
+
+  // embed.js detection path
+  it('accepts embed.js script with matching data-member slug', () => {
+    const html = '<div data-webring="ca" data-member="alice"></div><script src="https://webring.ca/embed.js" defer></script>'
+    expect(detectWidget(html, 'alice')).toBe(true)
+  })
+
+  it('accepts embed.js script without slug parameter', () => {
+    const html = '<div data-webring="ca" data-member="alice"></div><script src="https://webring.ca/embed.js"></script>'
+    expect(detectWidget(html)).toBe(true)
+  })
+
+  it('rejects embed.js script with wrong data-member slug', () => {
+    const html = '<div data-webring="ca" data-member="bob"></div><script src="https://webring.ca/embed.js"></script>'
+    expect(detectWidget(html, 'alice')).toBe(false)
+  })
+
+  it('rejects embed.js script without data-member attribute when slug checked', () => {
+    const html = '<div data-webring="ca"></div><script src="https://webring.ca/embed.js"></script>'
+    expect(detectWidget(html, 'alice')).toBe(false)
+  })
+
+  it('rejects embed.js script hidden in HTML comment', () => {
+    const html = '<!-- <script src="https://webring.ca/embed.js"></script> --><div data-webring="ca" data-member="alice"></div>'
+    expect(detectWidget(html, 'alice')).toBe(false)
+  })
+
+  it('embed.js does not require prev/next links in HTML', () => {
+    const html = '<div data-webring="ca" data-member="alice"></div><script src="https://webring.ca/embed.js"></script>'
+    expect(detectWidget(html, 'alice')).toBe(true)
   })
 
   it('rejects prev/next links without marker', () => {
@@ -270,6 +301,21 @@ describe('runHealthCheck', () => {
 
     const memberPuts = putSpy.mock.calls.filter(([key]) => key === 'members')
     expect(memberPuts).toHaveLength(0)
+  })
+
+  it('marks embed.js sites as ok without prev/next links in HTML', async () => {
+    const kv = createMockKV({ members: JSON.stringify([alice]) })
+    const embedHtml = '<div data-webring="ca" data-member="alice"></div><script src="https://webring.ca/embed.js" defer></script>'
+    mockFetch({
+      'https://alice.example.com': { ok: true, status: 200, body: embedHtml },
+    })
+
+    await runHealthCheck(kv)
+
+    const raw = await kv.get('health:alice')
+    const status: HealthStatus = JSON.parse(raw!)
+    expect(status.status).toBe('ok')
+    expect(status.consecutiveFails).toBe(0)
   })
 
   it('handles multiple members in parallel', async () => {

--- a/src/utils/widget.ts
+++ b/src/utils/widget.ts
@@ -20,8 +20,19 @@ function escapeRegex(value: string): string {
 export function detectWidget(html: string, slug?: string): boolean {
   const stripped = html.toLowerCase().replace(/<!--[\s\S]*?-->/g, '')
   const hasMarker = stripped.includes('data-webring="ca"') || stripped.includes('webring.ca/embed.js')
+  if (!hasMarker) return false
+
+  // embed.js path: script tag + matching data-member is sufficient
+  // because embed.js renders prev/next links client-side in a Shadow DOM
+  const hasEmbedScript = stripped.includes('webring.ca/embed.js')
+  if (hasEmbedScript) {
+    if (!slug) return true
+    return new RegExp(`data-member=["']${escapeRegex(slug.toLowerCase())}["']`).test(stripped)
+  }
+
+  // Manual widget path: requires prev + next links in raw HTML
   const slugPattern = slug ? escapeRegex(slug.toLowerCase()) : '[a-z0-9-]+'
   const hasPrev = new RegExp(`href=["'][^"']*webring\\.ca/prev/${slugPattern}(?:[?#/][^"']*)?["']`).test(stripped)
   const hasNext = new RegExp(`href=["'][^"']*webring\\.ca/next/${slugPattern}(?:[?#/][^"']*)?["']`).test(stripped)
-  return hasMarker && hasPrev && hasNext
+  return hasPrev && hasNext
 }


### PR DESCRIPTION
## Summary

- Add `public/embed.js` -- the embeddable widget script members add to their sites. Uses Shadow DOM for style isolation, CSS custom properties for customization (`--webring-bg`, `--webring-color`, `--webring-accent`, etc.), and inlined maple leaf SVG.
- Update `detectWidget()` to accept `webring.ca/embed.js` script + matching `data-member` slug as sufficient, without requiring prev/next links in raw HTML (since embed.js injects them client-side).
- Fix command injection risk in `scripts/validate.ts` by switching `execSync` to `execFileSync`.
- Add 8 new tests for embed.js detection path.

## Test plan

- [x] All 216 tests pass
- [x] Typecheck passes
- [ ] Manual: add embed snippet to a test HTML page, confirm widget renders
- [ ] Manual: verify CSS custom properties override defaults
- [ ] Manual: verify fallback (missing slug shows just webring.ca link + console warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)