### PR TITLE
fix: healthcheck bundle detection for SPAs + remove redundant KV read

### DIFF
--- a/src/__tests__/healthcheck.test.ts
+++ b/src/__tests__/healthcheck.test.ts
@@ -481,4 +481,21 @@ describe('runHealthCheck', () => {
       [],
     )
   })
+
+  it('marks SPA site as ok when widget is only in JS bundle', async () => {
+    const kv = createMockKV({ members: JSON.stringify([alice]) })
+    const spaHtml = '<html><head><script src="https://alice.example.com/assets/index.js"></script></head><body><div id="root"></div></body></html>'
+    const spaBundle = '{"data-member":"alice"},src:"https://webring.ca/embed.js"'
+    mockFetch({
+      'https://alice.example.com': { ok: true, status: 200, body: spaHtml },
+      'https://alice.example.com/assets/index.js': { ok: true, status: 200, body: spaBundle },
+    })
+
+    await runHealthCheck(kv)
+
+    const raw = await kv.get('health:alice')
+    const status: HealthStatus = JSON.parse(raw!)
+    expect(status.status).toBe('ok')
+    expect(status.consecutiveFails).toBe(0)
+  })
 })

--- a/src/cron/healthcheck.ts
+++ b/src/cron/healthcheck.ts
@@ -1,6 +1,6 @@
 import type { HealthStatus } from '../types'
 import { getMembers, setMembers, getHealthStatus, setHealthStatus } from '../data'
-import { detectWidget } from '../utils/widget'
+import { detectWidget, extractScriptUrls, detectWidgetInBundle } from '../utils/widget'
 import { notifyDiscord, type HealthEvent } from './notify'
 
 const USER_AGENTS = [
@@ -64,7 +64,26 @@ export async function runHealthCheck(
         }
 
         const body = await res.text()
-        const hasWidget = detectWidget(body, member.slug)
+        let hasWidget = detectWidget(body, member.slug)
+        if (!hasWidget) {
+          const scriptUrls = extractScriptUrls(body, member.url)
+          for (const scriptUrl of scriptUrls) {
+            try {
+              const jsRes = await fetch(scriptUrl, {
+                signal: AbortSignal.timeout(5000),
+                headers: { 'User-Agent': randomUA() },
+              })
+              if (!jsRes.ok) continue
+              const js = await jsRes.text()
+              if (detectWidgetInBundle(js, member.slug)) {
+                hasWidget = true
+                break
+              }
+            } catch {
+              // skip failed script fetches
+            }
+          }
+        }
         const frameable = isFrameable(res.headers)
 
         if (hasWidget) {

--- a/src/data.ts
+++ b/src/data.ts
@@ -38,6 +38,24 @@ export async function getEffectiveRingOrder(kv: KVNamespace): Promise<string[]> 
   return [...normalizedOrder, ...missingSlugs]
 }
 
+export async function getEffectiveRingOrderWithMembers(kv: KVNamespace): Promise<{ order: string[]; members: Member[] }> {
+  const [ringOrder, activeMembers] = await Promise.all([
+    getRingOrder(kv),
+    getActiveMembers(kv),
+  ])
+
+  const activeSlugs = activeMembers.map((m) => m.slug)
+  if (activeSlugs.length === 0) {
+    return { order: [], members: activeMembers }
+  }
+
+  const activeSlugSet = new Set(activeSlugs)
+  const normalizedOrder = ringOrder.filter((slug): slug is string => typeof slug === 'string' && activeSlugSet.has(slug))
+  const missingSlugs = activeSlugs.filter((slug) => !normalizedOrder.includes(slug))
+
+  return { order: [...normalizedOrder, ...missingSlugs], members: activeMembers }
+}
+
 export async function setMembers(kv: KVNamespace, members: Member[]): Promise<void> {
   await kv.put('members', JSON.stringify(members))
 }

--- a/src/data.ts
+++ b/src/data.ts
@@ -21,21 +21,8 @@ export async function getActiveMembers(kv: KVNamespace): Promise<Member[]> {
 }
 
 export async function getEffectiveRingOrder(kv: KVNamespace): Promise<string[]> {
-  const [order, activeMembers] = await Promise.all([
-    getRingOrder(kv),
-    getActiveMembers(kv),
-  ])
-
-  const activeSlugs = activeMembers.map((m) => m.slug)
-  if (activeSlugs.length === 0) {
-    return []
-  }
-
-  const activeSlugSet = new Set(activeSlugs)
-  const normalizedOrder = order.filter((slug): slug is string => typeof slug === 'string' && activeSlugSet.has(slug))
-  const missingSlugs = activeSlugs.filter((slug) => !normalizedOrder.includes(slug))
-
-  return [...normalizedOrder, ...missingSlugs]
+  const { order } = await getEffectiveRingOrderWithMembers(kv)
+  return order
 }
 
 export async function getEffectiveRingOrderWithMembers(kv: KVNamespace): Promise<{ order: string[]; members: Member[] }> {

--- a/src/routes/redirect.ts
+++ b/src/routes/redirect.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import type { Bindings } from '../types'
-import { getEffectiveRingOrder, getActiveMembers } from '../data'
+import { getEffectiveRingOrderWithMembers, getActiveMembers } from '../data'
 
 const SLUG_PATTERN = /^[a-z0-9-]+$/
 
@@ -25,10 +25,7 @@ app.get('/next/:slug', async (c) => {
   if (!isValidSlug(slug)) {
     return c.redirect('/', 302)
   }
-  const [order, activeMembers] = await Promise.all([
-    getEffectiveRingOrder(c.env.WEBRING),
-    getActiveMembers(c.env.WEBRING),
-  ])
+  const { order, members: activeMembers } = await getEffectiveRingOrderWithMembers(c.env.WEBRING)
 
   const membersBySlug = new Map(activeMembers.map((m) => [m.slug, m]))
   const idx = order.indexOf(slug)
@@ -54,10 +51,7 @@ app.get('/prev/:slug', async (c) => {
   if (!isValidSlug(slug)) {
     return c.redirect('/', 302)
   }
-  const [order, activeMembers] = await Promise.all([
-    getEffectiveRingOrder(c.env.WEBRING),
-    getActiveMembers(c.env.WEBRING),
-  ])
+  const { order, members: activeMembers } = await getEffectiveRingOrderWithMembers(c.env.WEBRING)
 
   const membersBySlug = new Map(activeMembers.map((m) => [m.slug, m]))
   const idx = order.indexOf(slug)


### PR DESCRIPTION
Two fixes in one small commit.

**Bug 1: healthcheck doesn't scan JS bundles (SPA sites get auto-deactivated)**

The nightly healthcheck called `detectWidget()` on raw HTML only. PR validation uses a two-step pipeline: raw HTML first, then `extractScriptUrls()` + `detectWidgetInBundle()` on same-origin JS bundles. The `detectWidget` JSDoc even says SPAs won't pass raw-HTML detection.

Result: a React/Vite/Next.js site passes CI via bundle detection but accumulates `widget_missing` every night and gets auto-deactivated after 7 consecutive failures.

Fix: the healthcheck now runs the same bundle-scan fallback after the raw HTML check, using the same 5 s timeout and random UA already in scope. New test covers the SPA case.

**Bug 2: 3 KV reads per /next or /prev click instead of 2**

`redirect.ts` called both `getEffectiveRingOrder()` (which internally calls `getActiveMembers()` = 1 KV read) and `getActiveMembers()` again directly = a second read of the same `members` key on every navigation click.

Fix: new `getEffectiveRingOrderWithMembers()` helper in `data.ts` does `Promise.all([getRingOrder(), getActiveMembers()])` once and returns both. Both `/next` and `/prev` handlers now call it instead of the two-call pattern. All 12 existing redirect tests still pass.