### PR TITLE
Add Double Down (hackerhouse.to)

### DIFF
--- a/members/double-down.json
+++ b/members/double-down.json
@@ -1,0 +1,6 @@
+{
+  "name": "Double Down",
+  "url": "https://hackerhouse.to",
+  "city": "Toronto",
+  "active": true
+}


### PR DESCRIPTION
Adds Double Down (Toronto AI founder cohort, https://hackerhouse.to) to the ring as `double-down`.

## Member entry

```json
{
  "name": "Double Down",
  "url": "https://hackerhouse.to",
  "city": "Toronto",
  "active": true
}
```

## Widget

Installed via `embed.js` in the site's shared landing footer. Should be detectable on the homepage HTML; if CI runs before the Double-Down deploy is live, please re-run after https://github.com/KaanEnt/Double-Down/pull/2 merges and Vercel finishes building.

Manual check:

```bash
curl -s https://hackerhouse.to/ | grep -E 'webring\.ca/embed\.js|data-member="double-down"'
```

## Checklist

- [x] Personal/project site by a Canadian builder (Toronto)
- [x] Slug matches `^[a-z0-9-]+$` and is unique
- [x] HTTPS URL, unique among existing members
- [x] City covered by `src/lib/city-coords.ts` (Toronto)
- [x] Widget installed via `embed.js` with matching `data-member="double-down"`