### PR TITLE
Add Nicole Jiang to the ring

### DIFF
--- a/members/nicole-jiang.json
+++ b/members/nicole-jiang.json
@@ -1,0 +1,6 @@
+{
+  "name": "Nicole Jiang",
+  "url": "https://nicolejiang.com",
+  "city": "Toronto",
+  "active": true
+}


### PR DESCRIPTION
Adds `members/nicole-jiang.json` for Nicole Jiang.

- **Site:** https://nicolejiang.com
- **City:** Toronto
- **Member slug:** `nicole-jiang`

The live site includes the recommended script embed with the matching `data-member="nicole-jiang"` attribute, and `https://webring.ca/embed.js` is reachable.